### PR TITLE
Added fixes to bug where Base Path was not defined in swagger docs

### DIFF
--- a/src/main/java/swurg/ui/Tab.java
+++ b/src/main/java/swurg/ui/Tab.java
@@ -136,15 +136,7 @@ public class Tab implements ITab {
     topPanel.add(filerPanel, gridBagConstraints);
 
     // scroll table
-    Object columns[] = {
-        "#",
-        "Method",
-        "Host",
-        "Protocol",
-        "Base Path",
-        "Endpoint",
-        "Param"
-    };
+    Object columns[] = { "#", "Method", "Host", "Protocol", "Base Path", "Endpoint", "Param" };
     Object rows[][] = {};
     this.table = new JTable(new DefaultTableModel(rows, columns) {
       @Override
@@ -157,9 +149,7 @@ public class Tab implements ITab {
       }
 
       @Override
-      public boolean isCellEditable(
-          int rows, int columns
-      ) {
+      public boolean isCellEditable(int rows, int columns) {
         return false;
       }
     });
@@ -197,9 +187,7 @@ public class Tab implements ITab {
     // enable column sorting
     this.table.setAutoCreateRowSorter(true);
     // enable table filtering
-    this.tableRowSorter = new TableRowSorter<>(
-        this.table.getModel()
-    );
+    this.tableRowSorter = new TableRowSorter<>(this.table.getModel());
     this.table.setRowSorter(tableRowSorter);
 
     // status panel
@@ -217,11 +205,9 @@ public class Tab implements ITab {
 
     if (this.resourceTextField.getText().isEmpty()) {
       JFileChooser fileChooser = new JFileChooser();
-      fileChooser.addChoosableFileFilter(
-          new FileNameExtensionFilter("Swagger JSON File (*.json)", "json"));
-      fileChooser.addChoosableFileFilter(
-          new FileNameExtensionFilter("Swagger YAML File (*.yml, *.yaml)", "yaml",
-              "yml"));
+      fileChooser.addChoosableFileFilter(new FileNameExtensionFilter("Swagger JSON File (*.json)", "json"));
+      fileChooser
+          .addChoosableFileFilter(new FileNameExtensionFilter("Swagger YAML File (*.yml, *.yaml)", "yaml", "yml"));
 
       if (fileChooser.showOpenDialog(this.rootPanel) == JFileChooser.APPROVE_OPTION) {
         File file = fileChooser.getSelectedFile();
@@ -239,9 +225,7 @@ public class Tab implements ITab {
     return this.table;
   }
 
-  public void printStatus(
-      String status, Color color
-  ) {
+  public void printStatus(String status, Color color) {
     this.statusLabel.setText(status);
     this.statusLabel.setForeground(color);
   }
@@ -252,8 +236,7 @@ public class Tab implements ITab {
 
     for (Scheme scheme : schemes) {
       for (Map.Entry<String, Path> path : swagger.getPaths().entrySet()) {
-        for (Map.Entry<HttpMethod, Operation> operation : path.getValue().getOperationMap()
-            .entrySet()) {
+        for (Map.Entry<HttpMethod, Operation> operation : path.getValue().getOperationMap().entrySet()) {
           StringBuilder stringBuilder = new StringBuilder();
 
           for (Parameter parameter : operation.getValue().getParameters()) {
@@ -264,35 +247,19 @@ public class Tab implements ITab {
             stringBuilder.setLength(stringBuilder.length() - 2);
           }
 
-          this.httpRequestResponses.add(
-              new HttpRequestResponse(
-                  this.extensionHelper.getBurpExtensionHelpers().buildHttpService(
-                      swagger.getHost().split(":")[0],
-                      this.extensionHelper
-                          .getPort(
-                              swagger,
-                              scheme
-                          ),
-                      this.extensionHelper
-                          .isUseHttps(
-                              scheme)
-                  ),
-                  this.extensionHelper.isUseHttps(scheme),
-                  this.extensionHelper
-                      .buildRequest(swagger, path,
-                          operation
-                      )
-              ));
+          this.httpRequestResponses.add(new HttpRequestResponse(
+              this.extensionHelper.getBurpExtensionHelpers().buildHttpService(swagger.getHost().split(":")[0],
+                  this.extensionHelper.getPort(swagger, scheme), this.extensionHelper.isUseHttps(scheme)),
+              this.extensionHelper.isUseHttps(scheme), this.extensionHelper.buildRequest(swagger, path, operation)));
 
-          defaultTableModel.addRow(new Object[]{
-              defaultTableModel.getRowCount(),
-              operation.getKey().toString(),
-              swagger.getHost().split(":")[0],
-              scheme.toValue().toUpperCase(),
-              swagger.getBasePath(),
-              path.getKey(),
-              stringBuilder.toString()
-          });
+          // Added check for null basepath
+          String basePath = "";
+          if (swagger.getBasePath() != null) {
+            basePath = swagger.getBasePath();
+          }
+          defaultTableModel.addRow(new Object[] { defaultTableModel.getRowCount(), operation.getKey().toString(),
+              swagger.getHost().split(":")[0], scheme.toValue().toUpperCase(), basePath, path.getKey(),
+              stringBuilder.toString() });
         }
       }
     }

--- a/src/main/java/swurg/utils/ExtensionHelper.java
+++ b/src/main/java/swurg/utils/ExtensionHelper.java
@@ -42,9 +42,7 @@ public class ExtensionHelper {
     return this.burpExtensionHelpers;
   }
 
-  public int getPort(
-      Swagger swagger, Scheme scheme
-  ) {
+  public int getPort(Swagger swagger, Scheme scheme) {
     int port;
 
     if (swagger.getHost().split(":").length > 1) {
@@ -63,19 +61,19 @@ public class ExtensionHelper {
   public boolean isUseHttps(Scheme scheme) {
     boolean useHttps;
 
-    useHttps = scheme.toValue().toUpperCase().equals("HTTPS") || scheme.toValue().toUpperCase()
-        .equals("WSS");
+    useHttps = scheme.toValue().toUpperCase().equals("HTTPS") || scheme.toValue().toUpperCase().equals("WSS");
 
     return useHttps;
   }
 
-  private List<String> buildHeaders(
-      Swagger swagger, Map.Entry<String, Path> path, Map.Entry<HttpMethod, Operation> operation
-  ) {
+  private List<String> buildHeaders(Swagger swagger, Map.Entry<String, Path> path,
+      Map.Entry<HttpMethod, Operation> operation) {
     List<String> headers = new ArrayList<>();
-
-    headers.add(
-        operation.getKey().toString() + " " + swagger.getBasePath() + path.getKey() + " HTTP/1.1");
+    String basePath = "";
+    if (swagger.getBasePath() != null) {
+      basePath = swagger.getBasePath();
+    }
+    headers.add(operation.getKey().toString() + " " + basePath + path.getKey() + " HTTP/1.1");
     headers.add("Host: " + swagger.getHost().split(":")[0]);
 
     if (CollectionUtils.isNotEmpty(operation.getValue().getProduces())) {
@@ -93,9 +91,8 @@ public class ExtensionHelper {
     return headers;
   }
 
-  public byte[] buildRequest(
-      Swagger swagger, Map.Entry<String, Path> path, Map.Entry<HttpMethod, Operation> operation
-  ) {
+  public byte[] buildRequest(Swagger swagger, Map.Entry<String, Path> path,
+      Map.Entry<HttpMethod, Operation> operation) {
     List<String> headers = buildHeaders(swagger, path, operation);
     byte[] httpMessage = this.burpExtensionHelpers.buildHttpMessage(headers, null);
 
@@ -110,14 +107,12 @@ public class ExtensionHelper {
       }
 
       switch (parameter.getIn()) {
-        case "body":
-          httpMessage = this.burpExtensionHelpers
-              .addParameter(httpMessage, this.burpExtensionHelpers
-                  .buildParameter(parameter.getName(), type, (byte) 1));
-        case "query":
-          httpMessage = this.burpExtensionHelpers
-              .addParameter(httpMessage, this.burpExtensionHelpers
-                  .buildParameter(parameter.getName(), type, (byte) 0));
+      case "body":
+        httpMessage = this.burpExtensionHelpers.addParameter(httpMessage,
+            this.burpExtensionHelpers.buildParameter(parameter.getName(), type, (byte) 1));
+      case "query":
+        httpMessage = this.burpExtensionHelpers.addParameter(httpMessage,
+            this.burpExtensionHelpers.buildParameter(parameter.getName(), type, (byte) 0));
       }
     }
 

--- a/src/test/java/swurg/process/LoaderTest.java
+++ b/src/test/java/swurg/process/LoaderTest.java
@@ -42,7 +42,11 @@ public class LoaderTest extends TestCase {
       logger.info("--- Swagger ---");
       logger.info("Info: " + swagger.getInfo());
       logger.info("Host: " + swagger.getHost());
-      logger.info("Base path: " + swagger.getBasePath());
+      String basePath = "";
+      if (swagger.getBasePath() != null) {
+        basePath = swagger.getBasePath();
+      }
+      logger.info("Base path: " + basePath);
       logger.info("Schemes: " + swagger.getSchemes());
       logger.info("Consumes: " + swagger.getConsumes());
       logger.info("Produces: " + swagger.getProduces());
@@ -53,8 +57,7 @@ public class LoaderTest extends TestCase {
         logger.info("--- Endpoint ---");
         logger.info("Path: " + path.getKey());
 
-        for (Map.Entry<HttpMethod, Operation> operation : path.getValue().getOperationMap()
-            .entrySet()) {
+        for (Map.Entry<HttpMethod, Operation> operation : path.getValue().getOperationMap().entrySet()) {
           logger.info("HTTP Method: " + operation.getKey().toString());
           logger.info("Schemes: " + operation.getValue().getSchemes());
           logger.info("Consumes: " + operation.getValue().getConsumes());
@@ -70,12 +73,9 @@ public class LoaderTest extends TestCase {
         }
       }
     } catch (IllegalArgumentException e) {
-      logger.error(String.format("%s is not a file or is an invalid URL", resource),
-          Color.RED);
+      logger.error(String.format("%s is not a file or is an invalid URL", resource), Color.RED);
     } catch (NullPointerException e) {
-      logger.error(String
-              .format("The OpenAPI specification in %s is ill formed and cannot be parsed",
-                  resource),
+      logger.error(String.format("The OpenAPI specification in %s is ill formed and cannot be parsed", resource),
           Color.RED);
     }
   }


### PR DESCRIPTION
Previously when undefined in swagger docs, the base path would return null. I've changed this so it returns an empty string. Otherwise when exporting to sitemap/repeater/etc. all URLs would be prefixed with `null` (e.g. `GET null/api/test HTTP/1.1`).

Also I think VS code may have reformatted all of the code (sorry about that).