### PR TITLE
Fixed issue where non default ports in the URI were not being honoured.

### DIFF
--- a/src/main/java/swurg/process/Loader.java
+++ b/src/main/java/swurg/process/Loader.java
@@ -108,7 +108,11 @@ public class Loader {
 
             try {
               URI uri = new URI(server.getUrl());
-              int port = uri.getScheme().equals("http") ? 80 : 443;
+              // take the port from the URI. If none specified, default to the default for http/https
+              int port = uri.getPort();
+              if(port == -1) {
+                port = uri.getScheme().equals("http") ? 80 : 443;
+              }
 
               HttpRequestResponse httpRequestResponse = new HttpRequestResponse(
                   this.callbacks.getHelpers().buildHttpService(uri.getHost(), port, port == 443), uri.getPort() == 443,


### PR DESCRIPTION
Fixed issue where non default ports in the URI were not being honoured.
e.g
http://localhost:8080 would resolve to 80.
Now it checks for port in the URI and defaults to http/80 https/443 only if no port is specified.